### PR TITLE
Spelling correction: initalise -> initialise

### DIFF
--- a/gap/BacktrackKit.gi
+++ b/gap/BacktrackKit.gi
@@ -211,7 +211,7 @@ InstallGlobalFunction( BTKit_Backtrack,
             BTKit_RestoreState(state, saved);
 
             # We found a permutation below so we return to the deepest
-            # special node node above
+            # special node above
             if found and (find_single_perm or ((not special) and (not parent_special))) then
                 Print("\<");
                 return true;

--- a/gap/BacktrackKit.gi
+++ b/gap/BacktrackKit.gi
@@ -68,11 +68,11 @@ end;
 #! @Description
 #! Set up a list of constraints. This should be called once, at
 #! the start of search after all constraints have been created.
-BTKit_InitaliseConstraints := function(state, tracer, rbase)
+BTKit_InitialiseConstraints := function(state, tracer, rbase)
     local c, filters;
     for c in state.conlist do
-        if IsBound(c.refine.initalise) then
-            filters := c.refine.initalise(state.ps, rbase);
+        if IsBound(c.refine.initialise) then
+            filters := c.refine.initialise(state.ps, rbase);
             if not BTKit_ApplyFilters(state.ps, tracer, filters) then
                 return false;
             fi;
@@ -82,7 +82,7 @@ BTKit_InitaliseConstraints := function(state, tracer, rbase)
 end;
 
 BTKit_FirstFixedPoint := function(state, tracer, rbase)
-    return BTKit_InitaliseConstraints(state, tracer, rbase) and
+    return BTKit_InitialiseConstraints(state, tracer, rbase) and
            BTKit_RefineConstraints(state, tracer, rbase);
 end;
 

--- a/gap/constraint.gd
+++ b/gap/constraint.gd
@@ -19,7 +19,7 @@
 #! arguments are listed below.
 #!
 #!
-#! * initalise (required) - Called when search begins (note, the partition
+#! * initialise (required) - Called when search begins (note, the partition
 #!   may already be split, by another constraint)
 #!
 #! * changed - One or splits occurred

--- a/gap/constraints/graphconstraints.g
+++ b/gap/constraints/graphconstraints.g
@@ -55,7 +55,7 @@ BTKit_Con.GraphTrans := function(graphL, graphR)
         name := "GraphTrans",
         check := {p} -> BTKit_OnGraph(p, graphL) = graphR,
         refine := rec(
-            initalise := check, 
+            initialise := check, 
             changed := check
         )
     );

--- a/gap/constraints/simpleconstraints.g
+++ b/gap/constraints/simpleconstraints.g
@@ -24,7 +24,7 @@ BTKit_MakeFixlistStabilizer := function(name, fixlist)
         name := name,
         check := {p} -> ForAll([1..Length(fixlist)], {i} -> fixlist[i] = fixlist[i^p]),
         refine := rec(
-            initalise := function(ps, rbase)
+            initialise := function(ps, rbase)
                 return filters;
             end)
     );
@@ -40,7 +40,7 @@ BTKit_MakeFixlistTransporter := function(name, fixlistL, fixlistR)
         name := name,
         check := {p} -> ForAll([1..Length(fixlistL)], {i} -> fixlistL[i] = fixlistR[i^p]),
         refine := rec(
-            initalise := function(ps, rbase)
+            initialise := function(ps, rbase)
                 if rbase = fail then
                     return filtersL;
                 else
@@ -160,7 +160,7 @@ BTKit_Con.InGroup := function(n, group)
         name := "InGroup",
         check := {p} -> p in group,
         refine := rec(
-            initalise := function(ps, rbase)
+            initialise := function(ps, rbase)
                 local fixedpoints, mapval, points;
                 fixedpoints := PS_FixedPoints(ps);
                 points := fillOrbits(fixedpoints);
@@ -229,7 +229,7 @@ BTKit_Con.PermCentralizer := function(n, fixedelt)
 
     r := rec( name := "PermCentralizer",
               check := {p} -> fixedelt ^ p = fixedelt,
-              refine := rec( initalise := function(ps, rbase)
+              refine := rec( initialise := function(ps, rbase)
                                local points;
                                points := fixByFixed(PS_FixedPoints(ps));
                                # Pass cyclepart just on the first call, for efficency

--- a/gap/constraints/tree/tree.g
+++ b/gap/constraints/tree/tree.g
@@ -10,9 +10,9 @@
 #         name := name,
 #         check := {p} -> ForAll(conlist, {c} -> c.check(p)),
 #         refine := rec(
-#             initalise := function(ps, rbase)
+#             initialise := function(ps, rbase)
 #                 local refines, gather;
-#                 refines := List(conlist, {c} -> c.initalise(ps, rbase));
+#                 refines := List(conlist, {c} -> c.initialise(ps, rbase));
 #                 gather := List([1..PS_Points(ps)], {i} -> List([1..Length(refines)], {x} -> refines[i](x)));
 #                 return {i} -> gather[i];
 #             end,
@@ -35,9 +35,9 @@
 #         name := name,
 #         check := {p} -> ForAll(conlist, {c} -> c.check(p)),
 #         refine := rec(
-#             initalise := function(ps, rbase)
+#             initialise := function(ps, rbase)
 #                 local refines, gather;
-#                 refines := List(conlist, {c} -> c.initalise(ps, rbase));
+#                 refines := List(conlist, {c} -> c.initialise(ps, rbase));
 #                 gather := List([1..PS_Points(ps)], {i} -> List([1..Length(refines)], {x} -> refines[i](x)));
 #                 return {i} -> gather[i];
 #             end,


### PR DESCRIPTION
The third of the four `i`s was missing in several locations.

I also fixed a typo in a comment (repeated word).