### PR TITLE
Use AutomorphismGroup not DigraphGroup in tests

### DIFF
--- a/tst/graph.tst
+++ b/tst/graph.tst
@@ -16,8 +16,8 @@ gap> testGraph := function(graph,verts)
 > local g1, g2, btgraph, ps;
 > ps := PartitionStack(verts);
 > btgraph := ToBTKit_Graph(graph, verts);
-> g1 := BTKit_SimpleSearch(ps, [BTKit_Con.GraphTrans( btgraph, btgraph)]);
-> g2 := DigraphGroup(graph);
+> g1 := BTKit_SimpleSearch(ps, [BTKit_Con.GraphTrans(btgraph, btgraph)]);
+> g2 := AutomorphismGroup(graph);
 > if g1 <> g2 then PrintFormatted("failure: {} {} {}", graph, g1, g2); fi;
 > end;;
 gap> graphs := ReadDigraphs(Filename(dir, "graph6.g6"));;


### PR DESCRIPTION
This is a super minor thing; but the `DigraphGroup` of a digraph is only required to be a subgroup of the automorphism group (it can be specified at the creation of the digraph). Although your digraphs almost surely won't have already had `DigraphGroup` set to something that's not the full automorphism group, I think it's still safer just to remove that and directly use `AutomorphismGroup`.