### PR TITLE
Fairly small documentation and formatting changes

### DIFF
--- a/gap/BacktrackKit.gd
+++ b/gap/BacktrackKit.gd
@@ -1,18 +1,16 @@
 #
-# BacktrackKit: An Extensible, easy to understand backtracking framework
+# BacktrackKit: An extensible, easy to understand backtracking framework
 #
 #! @Chapter Introduction
 #!
-#! BacktrackKit is a package which does some
-#! interesting and cool things
+#! BacktrackKit is a package which does some interesting and cool things.
 #!
 #! @Chapter Functionality
 #!
 #!
-#! @Section Example Methods
+#! @Section Example methods
 #!
-#! This section will describe the example
-#! methods of BacktrackKit
+#! This section will describe the example methods of BacktrackKit.
 
 
 DeclareGlobalFunction( "BTKit_BuildRBase" );
@@ -25,6 +23,6 @@ DeclareGlobalFunction( "BTKit_SimpleSinglePermSearch" );
 
 
 #! @Description
-#!  Information about backtrack search
+#! Information about backtrack search.
 DeclareInfoClass( "InfoBTKit" );
 SetInfoLevel(InfoBTKit, 0);

--- a/gap/constraint.gd
+++ b/gap/constraint.gd
@@ -6,7 +6,8 @@
 #! Informally, a <E>constraint</E> is a <K>true</K>/<K>false</K> mathematical
 #! property of permutations that is used to define a search problem in the
 #! symmetric group. For example, the property could be "belongs to the
-#! permutation group G", or "commutes with the permutation x".
+#! permutation group G", or "commutes with the permutation x", or "maps set
+#! A to set B", or "is an automorphism of the digraph D".
 #!
 #! In backtrackKit, a constraint is implemented as a record that must contain:
 #!
@@ -28,10 +29,12 @@
 #! The <C>refine</C> member of a constraint is a record that contains
 #! functions which, if present, will be called to inform the constraint
 #! of behaviour as search progresses, and to give the constraint the
-#! opportunity to influence the search.
-#! These functions will always be passed at least two arguments –
-#! firstly the constraint itself, and then the partition stack. Further
-#! arguments are listed below.
+#! opportunity to influence the search. The permissible functions are given
+#! described below.
+#!
+#! These functions will always be passed at least two arguments: firstly the
+#! constraint itself, and then the partition stack. Details of any further
+#! arguments are described with the relevant function, below.
 #!
 #TODO: the return value of <C>initialise</C> seems to be important.
 #! * <C>initialise</C> <E>(required)</E>. This is called when search begins.
@@ -43,7 +46,7 @@
 #TODO: this is incomplete
 #! * <C>changed</C> - One or splits occurred.
 #!
-#TODO: this is unclear
+#TODO: this is unclear. Also unimplemented.
 #! * <C>rBaseFinished</C> - The rBase has been created (is passed the rbase).
 #!   Constraints which care about this can use this to remember the rBase
 #!   construction is finished.

--- a/gap/constraints/simpleconstraints.g
+++ b/gap/constraints/simpleconstraints.g
@@ -1,15 +1,15 @@
 BTKit_Con := rec();
 
-# Any refiner which can be expressed as "stabilize an ordered partition"
+# Any constraint which can be expressed as "stabilize an ordered partition"
 # can be implemented easily and efficently, as we only need to handle
-# the root node of search (as we never gain more information as search
-# progresses).
+# the root node of search (as we never gain more information from such a
+# constraint as search progresses).
 # Therefore we have two general functions which implement:
 #
-# MakeFixlistStabilizer: Returns the refiner which implements
+# MakeFixlistStabilizer: Returns the constraint which implements
 #                        fixlist[i] = fixlist[i^p]
 #
-# MakeFixListTransporter: Returns the refiner which implements
+# MakeFixListTransporter: Returns the constraint which implements
 #                         fixlistL[i] = fixlistR[i^p]
 #
 # These are used to then implement refiners for sets, tuples
@@ -232,7 +232,7 @@ BTKit_Con.PermCentralizer := function(n, fixedelt)
               refine := rec( initialise := function(ps, rbase)
                                local points;
                                points := fixByFixed(PS_FixedPoints(ps));
-                               # Pass cyclepart just on the first call, for efficency
+                               # Pass cyclepart just on the first call, for efficiency
                                return {x} -> [points[x], cyclepart[x]];
                              end,
                              changed := function(ps, rbase)

--- a/gap/constraints/simpleconstraints.g
+++ b/gap/constraints/simpleconstraints.g
@@ -52,7 +52,7 @@ end;
 
 BTKit_Con.TupleStab := function(n, fixpoints)
     local fixlist, i;
-    fixlist := [1..n]*0;
+    fixlist := ListWithIdenticalEntries(n, 0);
     for i in [1..Length(fixpoints)] do
         fixlist[fixpoints[i]] := i;
     od;
@@ -61,11 +61,11 @@ end;
 
 BTKit_Con.TupleTransporter := function(n, fixpointsL, fixpointsR)
     local fixlistL, fixlistR, i;
-    fixlistL := [1..n]*0;
+    fixlistL := ListWithIdenticalEntries(n, 0);
     for i in [1..Length(fixpointsL)] do
         fixlistL[fixpointsL[i]] := i;
     od;
-    fixlistR := [1..n]*0;
+    fixlistR := ListWithIdenticalEntries(n, 0);
     for i in [1..Length(fixpointsR)] do
         fixlistR[fixpointsR[i]] := i;
     od;
@@ -74,7 +74,7 @@ end;
 
 BTKit_Con.SetStab := function(n, fixset)
     local fixlist, i;
-    fixlist := [1..n]*0;
+    fixlist := ListWithIdenticalEntries(n, 0);
     for i in [1..Length(fixset)] do
         fixlist[fixset[i]] := 1;
     od;
@@ -83,11 +83,11 @@ end;
 
 BTKit_Con.SetTransporter := function(n, fixsetL, fixsetR)
     local fixlistL, fixlistR, i;
-    fixlistL := [1..n]*0;
+    fixlistL := ListWithIdenticalEntries(n, 0);
     for i in [1..Length(fixsetL)] do
         fixlistL[fixsetL[i]] := 1;
     od;
-    fixlistR := [1..n]*0;
+    fixlistR := ListWithIdenticalEntries(n, 0);
     for i in [1..Length(fixsetR)] do
         fixlistR[fixsetR[i]] := 1;
     od;
@@ -96,7 +96,7 @@ end;
 
 BTKit_Con.OrderedPartitionStab := function(n, fixpart)
     local fixlist, i, j;
-    fixlist := [1..n]*0;
+    fixlist := ListWithIdenticalEntries(n, 0);
     for i in [1..Length(fixpart)] do
         for j in fixpart[i] do
             fixlist[j] := i;
@@ -107,13 +107,13 @@ end;
 
 BTKit_Con.OrderedPartitionTransporter := function(n, fixpartL, fixpartR)
     local fixlistL, fixlistR, i, j;
-    fixlistL := [1..n]*0;
+    fixlistL := ListWithIdenticalEntries(n, 0);
     for i in [1..Length(fixpartL)] do
         for j in fixpartL[i] do
             fixlistL[j] := i;
         od;
     od;
-    fixlistR := [1..n]*0;
+    fixlistR := ListWithIdenticalEntries(n, 0);
     for i in [1..Length(fixpartR)] do
         for j in fixpartR[i] do
             fixlistR[j] := i;
@@ -212,7 +212,7 @@ BTKit_Con.PermCentralizer := function(n, fixedelt)
 
     fixByFixed := function(pointlist)
         local part, s, p;
-        part := [1..n] * 0;
+        part := ListWithIdenticalEntries(n, 0);
         s := 1;
         for p in pointlist do
             if part[p] = 0 then

--- a/gap/partitionstack.gd
+++ b/gap/partitionstack.gd
@@ -1,3 +1,6 @@
+#
+# BacktrackKit: An extensible, easy to understand backtracking framework
+#
 #! @Chapter Ordered partition stack
 #!
 #! An <E>ordered partition stack</E> is an ordered partition which supports
@@ -53,7 +56,7 @@ DeclareOperation("PS_Fixed", [IsPartitionStack]);
 
 #! @Description
 #! Return the current partition state of the partition stack <A>PS</A> as a
-#! list of sets.
+#! list of sets, in the correct order.
 #!
 #! @Arguments PS
 #! @Returns a list of lists of positive integers.

--- a/gap/partitionstack.gd
+++ b/gap/partitionstack.gd
@@ -20,10 +20,12 @@ DeclareCategory("IsPartitionStack", IsObject);
 BindGlobal( "PartitionStackFamily", NewFamily("PartitionStackFamily") );
 
 
-DeclareRepresentation( "IsPartitionStackRep", IsPartitionStack and IsComponentObjectRep, []);
-BindGlobal( "PartitionStackType", NewType(PartitionStackFamily, IsPartitionStackRep));
-BindGlobal( "PartitionStackTypeMutable", NewType(PartitionStackFamily,
-                                        IsPartitionStackRep and IsMutable));
+DeclareRepresentation( "IsPartitionStackRep",
+                       IsPartitionStack and IsComponentObjectRep, []);
+BindGlobal( "PartitionStackType",
+            NewType(PartitionStackFamily, IsPartitionStackRep));
+BindGlobal( "PartitionStackTypeMutable",
+            NewType(PartitionStackFamily, IsPartitionStackRep and IsMutable));
 
 #! @Description
 #! Return the number of points on which the partition stack <A>PS</A> is
@@ -120,7 +122,8 @@ DeclareOperation("PS_RevertToCellCount", [IsPartitionStack, IsPosInt]);
 #!
 #! @Arguments PS, t, i, f
 #! @Returns <K>true</K> or <K>false</K>.
-DeclareOperation("PS_SplitCellByFunction", [IsPartitionStack, IsTracer, IsPosInt, IsFunction]);
+DeclareOperation("PS_SplitCellByFunction",
+                 [IsPartitionStack, IsTracer, IsPosInt, IsFunction]);
 
 #! @Description
 #! Apply <C>PS_SplitCellByFunction</C> to every active cell in the partition
@@ -128,7 +131,8 @@ DeclareOperation("PS_SplitCellByFunction", [IsPartitionStack, IsTracer, IsPosInt
 #!
 #! @Arguments PS, t, f
 #! @Returns <K>true</K> or <K>false</K>.
-DeclareOperation("PS_SplitCellsByFunction", [IsPartitionStack, IsTracer, IsFunction]);
+DeclareOperation("PS_SplitCellsByFunction",
+                 [IsPartitionStack, IsTracer, IsFunction]);
 
 #! @Description
 #! Split cell <A>i</A> of the current partition state of the partition stack
@@ -138,14 +142,16 @@ DeclareOperation("PS_SplitCellsByFunction", [IsPartitionStack, IsTracer, IsFunct
 #! The second argument <A>t</A> should be a tracer.
 #!
 #! @Arguments PS, t, i, f
-DeclareOperation("PS_SplitCellByUnorderedFunction", [IsPartitionStack, IsTracer, IsPosInt, IsFunction]);
+DeclareOperation("PS_SplitCellByUnorderedFunction",
+                 [IsPartitionStack, IsTracer, IsPosInt, IsFunction]);
 
 #! @Description
 #! Apply <C>PS_SplitCellByUnorderedFunction</C> to every active cell in the
 #! partition stack <A>PS</A>.
 #!
 #! @Arguments PS, t, f
-DeclareOperation("PS_SplitCellsByUnorderedFunction", [IsPartitionStack, IsTracer, IsFunction]);
+DeclareOperation("PS_SplitCellsByUnorderedFunction",
+                 [IsPartitionStack, IsTracer, IsFunction]);
 
 DeclareOperation("PS_UNSAFE_CellSlice", [IsPartitionStack, IsPosInt]);
 

--- a/gap/partitionstack.gi
+++ b/gap/partitionstack.gi
@@ -32,7 +32,7 @@ function(n)
     marks := ListWithIdenticalEntries(n + 1, 0);
     marks[1] := 1;
     marks[n+1] := n+1;
-    return Objectify(PartitionStackTypeMutable, 
+    return Objectify(PartitionStackTypeMutable,
         rec(len := n,
             vals := [1..n],
             invvals := [1..n],
@@ -45,12 +45,10 @@ end);
 
 InstallMethod(IsInternallyConsistent, [IsPartitionStack],
     function(ps)
-        local n, i, fixedcells, ret;
+        local n, i, fixedcells;
         n := ps!.len;
         if Length(ps!.marks) <> n+1 then return false; fi;
-        ret := ps!.marks[1] = 1 and
-               ps!.marks[n+1] = n+1;
-        if not ret then return false; fi;
+        if ps!.marks[1] <> 1 or ps!.marks[n+1] <> n+1 then return false; fi;
 
         if Length(ps!.cellstart) <> Length(ps!.cellsize) then return false; fi;
         if ForAny([1..n],
@@ -145,7 +143,7 @@ BindGlobal("_PSR_SplitCell",
         splitcellsize := ps!.cellsize[cell];
 
         newcellid := Length(ps!.cellstart) + 1;
-        
+
         ps!.cellstart[newcellid] := splitpos;
         ps!.cellsize[newcellid] := splitcellsize - (index - 1);
 
@@ -162,9 +160,11 @@ BindGlobal("_PSR_SplitCell",
         fi;
 
         Add(ps!.splits, cell);
-        return MaybeAddEvent(t, rec(oldcell := cell, newcell := newcellid,
-                               oldsize := index - 1, newsize := splitcellsize - (index - 1),
-                               reason := reason));
+        return MaybeAddEvent(t, rec(oldcell := cell,
+                                    newcell := newcellid,
+                                    oldsize := index - 1,
+                                    newsize := splitcellsize - (index - 1),
+                                    reason  := reason));
     end);
 
 InstallMethod(PS_SplitCellsByFunction, [IsPartitionStack, IsTracer, IsFunction],

--- a/gap/partitionstack.gi
+++ b/gap/partitionstack.gi
@@ -178,7 +178,8 @@ InstallMethod(PS_SplitCellsByFunction, [IsPartitionStack, IsTracer, IsFunction],
         return true;
     end);
 
-InstallMethod(PS_SplitCellByFunction, [IsPartitionStackRep, IsTracer, IsPosInt, IsFunction],
+InstallMethod(PS_SplitCellByFunction,
+    [IsPartitionStackRep, IsTracer, IsPosInt, IsFunction],
     function(ps, t, cell, f)
         local slice, slicelen, lastval, curval, i, success;
 
@@ -199,7 +200,8 @@ InstallMethod(PS_SplitCellByFunction, [IsPartitionStackRep, IsTracer, IsPosInt, 
         return MaybeAddEvent(t, rec(endsplit := true, reason := f(slice[1])));
     end);
 
-InstallMethod(PS_SplitCellByUnorderedFunction, [IsPartitionStack, IsTracer, IsPosInt, IsFunction],
+InstallMethod(PS_SplitCellByUnorderedFunction,
+    [IsPartitionStack, IsTracer, IsPosInt, IsFunction],
     function(ps, t, cell, f)
         local slice, slicelen, lastval, curval, i;
 

--- a/gap/partitionstack.gi
+++ b/gap/partitionstack.gi
@@ -28,8 +28,8 @@
 InstallGlobalFunction(PartitionStack,
 function(n)
     local marks;
-    # Make array full of 0s
-    marks := [1..n+1] * 0;
+    # Make array full of n+1 0s
+    marks := ListWithIdenticalEntries(n + 1, 0);
     marks[1] := 1;
     marks[n+1] := n+1;
     return Objectify(PartitionStackTypeMutable, 

--- a/gap/tracer.gd
+++ b/gap/tracer.gd
@@ -32,20 +32,24 @@ DeclareCategory("IsTracer", IsObject);
 BindGlobal( "TracerFamily", NewFamily("TracerFamily") );
 
 
-DeclareRepresentation( "IsRecordingTracerRep", IsTracer and IsComponentObjectRep, []);
+DeclareRepresentation( "IsRecordingTracerRep",
+                       IsTracer and IsComponentObjectRep, []);
 BindGlobal( "RecordingTracerType", NewType(TracerFamily, IsRecordingTracerRep));
-BindGlobal( "RecordingTracerTypeMutable", NewType(TracerFamily,
-                                        IsRecordingTracerRep and IsMutable));
+BindGlobal( "RecordingTracerTypeMutable",
+            NewType(TracerFamily, IsRecordingTracerRep and IsMutable));
 
-DeclareRepresentation( "IsFollowingTracerRep", IsTracer and IsComponentObjectRep, []);
+DeclareRepresentation( "IsFollowingTracerRep",
+                       IsTracer and IsComponentObjectRep, []);
 BindGlobal( "FollowingTracerType", NewType(TracerFamily, IsFollowingTracerRep));
-BindGlobal( "FollowingTracerTypeMutable", NewType(TracerFamily,
-                                        IsFollowingTracerRep and IsMutable));
+BindGlobal( "FollowingTracerTypeMutable",
+            NewType(TracerFamily, IsFollowingTracerRep and IsMutable));
 
-DeclareRepresentation( "IsCanonicalisingTracerRep", IsTracer and IsComponentObjectRep, []);
-BindGlobal( "CanonicalisingTracerType", NewType(TracerFamily, IsCanonicalisingTracerRep));
-BindGlobal( "CanonicalisingTracerTypeMutable", NewType(TracerFamily,
-                                        IsCanonicalisingTracerRep and IsMutable));
+DeclareRepresentation( "IsCanonicalisingTracerRep",
+                       IsTracer and IsComponentObjectRep, []);
+BindGlobal( "CanonicalisingTracerType",
+            NewType(TracerFamily, IsCanonicalisingTracerRep));
+BindGlobal( "CanonicalisingTracerTypeMutable",
+            NewType(TracerFamily, IsCanonicalisingTracerRep and IsMutable));
 
 #! @Description
 #! Add an event to the trace.

--- a/gap/tracer.gd
+++ b/gap/tracer.gd
@@ -1,33 +1,39 @@
+#
+# BacktrackKit: An extensible, easy to understand backtracking framework
+#
 #! @Chapter Ordered tracer
 #!
-#! An <E>ordered tracer</E> is an ordered partition which supports
-#! splitting a cell, and then later undoing a change, reverting the
-#! partition back to an earlier state.
+#! An <E>ordered tracer</E> is...
+# TODO complete the description of an ordered tracer.
 
 
 #! @Section API
 #!
 #! @Description
-#! Constructor for tracers.
+#! Constructor for recording tracers.
 #! @Arguments
-#! @Returns a tracer which records the state.
+#! @Returns a recording tracer.
 DeclareGlobalFunction("RecordingTracer");
 
 #! @Description
-#! Constructor for tracers.
-#! @Arguments
-#! @Returns a tracer which follows a previous tracer.
+#! If the argument <A>t</A> is a tracer, then this constructs a tracer that
+#! follows <A>t</A>.
+#! @Arguments t
+#! @Returns a following tracer.
 DeclareGlobalFunction("FollowingTracer");
 
 #! @Description
-#! Constructor for tracers.
+#! Constructor for canonicalising tracers.
 #! @Arguments
-#! @Returns a tracer which produces a canonical image.
+#! @Returns a canonicalising tracer.
 DeclareGlobalFunction("CanonicalisingTracer");
 
 
 #! @Description
-#! Category of tracers.
+#! The category of tracers.
+#!
+#! @Arguments t
+#! @Returns <K>true</K> or <K>false</K>.
 DeclareCategory("IsTracer", IsObject);
 BindGlobal( "TracerFamily", NewFamily("TracerFamily") );
 
@@ -52,18 +58,28 @@ BindGlobal( "CanonicalisingTracerTypeMutable",
             NewType(TracerFamily, IsCanonicalisingTracerRep and IsMutable));
 
 #! @Description
-#! Add an event to the trace.
+#! Add the arbitrary GAP object <A>o</A> as an event to the tracer <A>t</A>.
+#! This returns <K>true</K> if the event is accepted by the tracer, and
+#! <K>false</K> if not. Events are always accepted by recording tracers.
 #!
-#! @Returns a boolean, which indicates whether the event is accepted by the
-#! trace.
+#! @Returns <K>true</K> or <K>false</K>.
+#! @Arguments t, o
 DeclareOperation("AddEvent", [IsTracer, IsObject]);
 
 #! @Description
-#! Get the length of a trace.
+#! Get the number of events in the tracer <A>t</A>.
+#!
+#! @Returns an integer.
+#! @Arguments t
 DeclareOperation("TraceLength", [IsTracer]);
 
 #! @Description
-#! Get the list of events in the trace.
+#! Get the event at position <A>i</A> in the tracer <A>t</A>.
+#! The argument <A>i</A> must lie in the range
+#! <C>[1..TraceLength(<A>t</A>)]</C>.
+#!
+#! @Returns a GAP object.
+#! @Arguments t, i
 DeclareOperation("TraceEvent", [IsTracer, IsPosInt]);
 
 DeclareInfoClass("InfoTrace");

--- a/gap/tracer.gi
+++ b/gap/tracer.gi
@@ -3,10 +3,7 @@
 ##
 
 InstallGlobalFunction(RecordingTracer,
-function()
-    return Objectify(RecordingTracerTypeMutable, 
-        rec(trace := []) );
-end);
+{} -> Objectify(RecordingTracerTypeMutable, rec(trace := []) ));
 
 InstallMethod(AddEvent, [IsRecordingTracerRep and IsMutable, IsObject],
     function(tracer, o)
@@ -21,13 +18,16 @@ InstallMethod(TraceEvent, [IsRecordingTracerRep, IsPosInt],
 
 InstallMethod(ViewObj, [IsRecordingTracerRep],
 function(t)
-  Print("<recording tracer of length ", TraceLength(t), ">");
+    PrintFormatted("<recording tracer of length {}>", TraceLength(t));
 end);
 
 
 InstallGlobalFunction(FollowingTracer,
 function(trace)
-    return Objectify(FollowingTracerTypeMutable, 
+    if IsFollowingTracerRep(trace) then
+        ErrorNoReturn("a following tracer cannot follow a following tracer,");
+    fi;
+    return Objectify(FollowingTracerTypeMutable,
         rec(existingTrace := trace, pos := 1) );
 end);
 
@@ -53,12 +53,9 @@ InstallMethod(TraceEvent, [IsFollowingTracerRep, IsPosInt],
 
 InstallMethod(ViewObj, [IsFollowingTracerRep],
 function(t)
-    Print("<following tracer of length ", TraceLength(t), ">");
+    PrintFormatted("<following tracer of length {}>", TraceLength(t));
 end);
 
 
 InstallGlobalFunction(CanonicalisingTracer,
-function()
-    return Objectify(CanonicalisingTracerTypeMutable, 
-        rec(trace := [], pos := 1) );
-end);
+{} -> Objectify(CanonicalisingTracerTypeMutable, rec(trace := [], pos := 1)));

--- a/gap/tracer.gi
+++ b/gap/tracer.gi
@@ -14,8 +14,10 @@ InstallMethod(AddEvent, [IsRecordingTracerRep and IsMutable, IsObject],
         return true;
     end);
 
-InstallMethod(TraceLength, [IsRecordingTracerRep], x -> Length(x!.trace));
-InstallMethod(TraceEvent, [IsRecordingTracerRep, IsPosInt], {x,i} -> x!.trace[i]);
+InstallMethod(TraceLength, [IsRecordingTracerRep],
+{x} -> Length(x!.trace));
+InstallMethod(TraceEvent, [IsRecordingTracerRep, IsPosInt],
+{x,i} -> x!.trace[i]);
 
 InstallMethod(ViewObj, [IsRecordingTracerRep],
 function(t)
@@ -34,9 +36,9 @@ InstallMethod(AddEvent, [IsFollowingTracerRep and IsMutable, IsObject],
         if tracer!.pos > TraceLength(tracer!.existingTrace) then
             Info(InfoTrace, 1, "Too long!");
             return false;
-        fi;
-        if TraceEvent(tracer!.existingTrace, tracer!.pos) <> o then
-            Info(InfoTrace, 1, "Trace violation", TraceEvent(tracer!.existingTrace, tracer!.pos), ":", o);
+        elif TraceEvent(tracer!.existingTrace, tracer!.pos) <> o then
+            Info(InfoTrace, 1, StringFormatted("Trace violation {}:{}",
+                               TraceEvent(tracer!.existingTrace, tracer!.pos), o));
             tracer!.pos := infinity;
             return false;
         fi;
@@ -44,8 +46,10 @@ InstallMethod(AddEvent, [IsFollowingTracerRep and IsMutable, IsObject],
         return true;
     end);
 
-InstallMethod(TraceLength, [IsFollowingTracerRep], {x} -> TraceLength(x!.existingTrace));
-InstallMethod(TraceEvent, [IsFollowingTracerRep, IsPosInt], {x,i} -> TraceEvent(x!.existingTrace, i));
+InstallMethod(TraceLength, [IsFollowingTracerRep],
+{x} -> TraceLength(x!.existingTrace));
+InstallMethod(TraceEvent, [IsFollowingTracerRep, IsPosInt],
+{x,i} -> TraceEvent(x!.existingTrace, i));
 
 InstallMethod(ViewObj, [IsFollowingTracerRep],
 function(t)

--- a/tst/basic.tst
+++ b/tst/basic.tst
@@ -8,9 +8,13 @@ gap> G = SymmetricGroup(3);
 true
 gap> G := BTKit_SimpleSearch(ps3, [BTKit_Con.InGroup(3, Group((1,2)(3,4)))]);
 Group(())
-gap> G := BTKit_SimpleSearch(ps6, [BTKit_Con.InGroup(6, AlternatingGroup(6)), BTKit_Con.SetStab(6,[2,4,6]), BTKit_Con.TupleStab(6,[1,2]) ]);;
-gap> G = Intersection(AlternatingGroup(6), Stabilizer(AlternatingGroup(6), [2,4,6], OnSets), Stabilizer(AlternatingGroup(6), [1,2], OnTuples));
+gap> G := BTKit_SimpleSearch(ps6, [BTKit_Con.InGroup(6, AlternatingGroup(6)),
+>                                  BTKit_Con.SetStab(6, [2,4,6]),
+>                                  BTKit_Con.TupleStab(6, [1,2])]);;
+gap> G = Intersection(AlternatingGroup(6),
+>                     Stabilizer(AlternatingGroup(6), [2,4,6], OnSets),
+>                     Stabilizer(AlternatingGroup(6), [1,2], OnTuples));
 true
 gap> graph := [ [ [1,2] ], [ [1,3] ], [ [1,1] ] ];;
-gap> BTKit_SimpleSearch(ps3, [BTKit_Con.GraphTrans( graph, graph)]) = Group( (1,2,3) );
+gap> BTKit_SimpleSearch(ps3, [BTKit_Con.GraphTrans(graph, graph)]) = Group( (1,2,3) );
 true

--- a/tst/basicTransport.tst
+++ b/tst/basicTransport.tst
@@ -3,15 +3,22 @@ gap> ps3 := PartitionStack(3);
 [ [ 1, 2, 3 ] ]
 gap> ps6 := PartitionStack(6);
 [ [ 1, 2, 3, 4, 5, 6 ] ]
-gap> p := BTKit_SimpleSinglePermSearch(ps3, [BTKit_Con.InGroup(3, SymmetricGroup(3))]);;
+gap> p := BTKit_SimpleSinglePermSearch(ps3,
+>           [BTKit_Con.InGroup(3, SymmetricGroup(3))]);;
 gap> p in SymmetricGroup(3);
 true
-gap> p := BTKit_SimpleSinglePermSearch(ps3, [BTKit_Con.InGroup(3, SymmetricGroup(3)), BTKit_Con.SetTransporter(3,[1,2],[2,3])]);;
+gap> p := BTKit_SimpleSinglePermSearch(ps3,
+>           [BTKit_Con.InGroup(3, SymmetricGroup(3)),
+>            BTKit_Con.SetTransporter(3,[1,2],[2,3])]);;
 gap> OnSets([1,2], p) = [2,3];
 true
-gap> p := BTKit_SimpleSinglePermSearch(ps6, [BTKit_Con.InGroup(6, AlternatingGroup(6)), BTKit_Con.SetTransporter(6,[2,4,6], [1,2,3]) ]);;
+gap> p := BTKit_SimpleSinglePermSearch(ps6,
+>           [BTKit_Con.InGroup(6, AlternatingGroup(6)),
+>            BTKit_Con.SetTransporter(6,[2,4,6],[1,2,3])]);;
 gap> OnSets([2,4,6], p) = [1,2,3];
 true
-gap> p := BTKit_SimpleSinglePermSearch(ps6, [BTKit_Con.InGroup(6, AlternatingGroup(6)), BTKit_Con.TupleTransporter(6,[2,4,6], [1,2,3]) ]);;
+gap> p := BTKit_SimpleSinglePermSearch(ps6,
+>           [BTKit_Con.InGroup(6, AlternatingGroup(6)),
+>            BTKit_Con.TupleTransporter(6,[2,4,6], [1,2,3]) ]);;
 gap> OnTuples([2,4,6], p) = [1,2,3];
 true

--- a/tst/graph.tst
+++ b/tst/graph.tst
@@ -11,7 +11,6 @@ gap> ToBTKit_Graph := function(g, verts)
 >    od;
 >    return graph;
 > end;;
-gap> dir := DirectoriesPackageLibrary( "BacktrackKit", "tst" );;
 gap> testGraph := function(graph,verts)
 > local g1, g2, btgraph, ps;
 > ps := PartitionStack(verts);
@@ -20,5 +19,6 @@ gap> testGraph := function(graph,verts)
 > g2 := DigraphGroup(graph);
 > if g1 <> g2 then PrintFormatted("failure: {} {} {}", graph, g1, g2); fi;
 > end;;
+gap> dir := DirectoriesPackageLibrary( "BacktrackKit", "tst" );;
 gap> graphs := ReadDigraphs(Filename(dir, "graph6.g6"));;
 gap> for g in graphs do testGraph(g, 6); od;


### PR DESCRIPTION
Hopefully the documentation changes are self-evident; the documentation is still a work-in-progress of course.

I've shortened most lines that were longer than 80 characters. If you hate this, then fair enough, but I think it improves readability, at least for me.

I replaced things like `[1..n]*0`, which is perhaps a little bit opaque, with `ListWithIdenticalEntries`, which is hopefully more understandable to people looking at the code, and is well implemented as well, so won't be a performance penalty.

And I've changed the look of a few other bits of code, again to things that I prefer and would argue that make it easier for outsiders to potentially read. But again, I'm happy if you disagree.